### PR TITLE
Removing NDA Text from Speech API pages

### DIFF
--- a/Content/en-us/Speech/API-Reference-REST/BingVoiceOutput.md
+++ b/Content/en-us/Speech/API-Reference-REST/BingVoiceOutput.md
@@ -9,15 +9,6 @@ Weight: 180
 # Bing Text To Speech API
 
 
-### Non Disclosure Agreement.
-
-© 2016 Microsoft. All rights reserved.
-
-This document is provided “as-is”. Information and views expressed in this document, including URLs and other Internet website references, may change without notice.
-
-Examples are provided for illustration only.
-
-This document does not provide you with any legal rights to intellectual property in any Microsoft product. You may copy and use this document for your internal reference purposes. This document is confidential and proprietary to Microsoft. It can be used only in agreement with a non-disclosure agreement.
 
 --------------------------------------------------
 ## Contents

--- a/Content/en-us/Speech/API-Reference-REST/BingVoiceRecognition.md
+++ b/Content/en-us/Speech/API-Reference-REST/BingVoiceRecognition.md
@@ -8,14 +8,6 @@ Weight: 90
 # Bing Voice Recognition API
 
 
-### Non Disclosure Agreement. 
-© 2016 Microsoft. All rights reserved.
-
-This document is provided “as-is”. Information and views expressed in this document, including URLs and other Internet website references, may change without notice. 
-
-Examples are provided for illustration only. 
-
-This document does not provide you with any legal rights to intellectual property in any Microsoft product. You may copy and use this document for your internal reference purposes. This document is confidential and proprietary to Microsoft. It can be used only in agreement with a non-disclosure agreement. 
 
 --------------------------------------------------
 ### Contents


### PR DESCRIPTION
I think the text removed in this patch was intended for an internal or earlier version of the docs.
