### PR TITLE
fix(face_api): invalid json as detect response

### DIFF
--- a/Content/en-us/Face/QuickStarts/CSharp.md
+++ b/Content/en-us/Face/QuickStarts/CSharp.md
@@ -215,7 +215,6 @@ A successful response will be returned in JSON. Following is an example of a suc
                 "mustache": 0.8,
                 "beard": 0.1,
                 "sideburns": 0.02
-                }
             },
             "glasses": "sunglasses",
             "headPose": {

--- a/Content/en-us/Face/QuickStarts/Java.md
+++ b/Content/en-us/Face/QuickStarts/Java.md
@@ -208,7 +208,6 @@ A successful response will be returned in JSON. The following is an example of a
                 "mustache": 0.8,
                 "beard": 0.1,
                 "sideburns": 0.02
-                }
             },
             "glasses": "sunglasses",
             "headPose": {

--- a/Content/en-us/Face/QuickStarts/JavaScript.md
+++ b/Content/en-us/Face/QuickStarts/JavaScript.md
@@ -193,7 +193,6 @@ A successful response will be returned in JSON. Following is an example of a suc
                 "mustache": 0.8,
                 "beard": 0.1,
                 "sideburns": 0.02
-                }
             },
             "glasses": "sunglasses",
             "headPose": {

--- a/Content/en-us/Face/QuickStarts/PHP.md
+++ b/Content/en-us/Face/QuickStarts/PHP.md
@@ -196,7 +196,6 @@ A successful response will be returned in JSON. Following is an example of a suc
                 "mustache": 0.8,
                 "beard": 0.1,
                 "sideburns": 0.02
-                }
             },
             "glasses": "sunglasses",
             "headPose": {

--- a/Content/en-us/Face/QuickStarts/Python.md
+++ b/Content/en-us/Face/QuickStarts/Python.md
@@ -211,7 +211,6 @@ A successful response will be returned in JSON. Following is an example of a suc
                 "mustache": 0.8,
                 "beard": 0.1,
                 "sideburns": 0.02
-                }
             },
             "glasses": "sunglasses",
             "headPose": {

--- a/Content/en-us/Face/QuickStarts/Ruby.md
+++ b/Content/en-us/Face/QuickStarts/Ruby.md
@@ -179,7 +179,6 @@ A successful response will be returned in JSON. Following is an example of a suc
                 "mustache": 0.8,
                 "beard": 0.1,
                 "sideburns": 0.02
-                }
             },
             "glasses": "sunglasses",
             "headPose": {

--- a/Content/en-us/Face/QuickStarts/curl.md
+++ b/Content/en-us/Face/QuickStarts/curl.md
@@ -163,7 +163,6 @@ A successful response will be returned in JSON. Following is an example of a suc
                 "mustache": 0.8,
                 "beard": 0.1,
                 "sideburns": 0.02
-                }
             },
             "glasses": "sunglasses",
             "headPose": {


### PR DESCRIPTION
Fixed invalid json as detect response example. Note that the problem exists in API definition(swagger and WADL api definitions are affected)
https://westus.dev.cognitive.microsoft.com/docs/services/563879b61984550e40cbbe8d/export?DocumentFormat=Swagger&ApiName=Face%20API%20-%20V1.0
https://westus.dev.cognitive.microsoft.com/docs/services/563879b61984550e40cbbe8d/export?DocumentFormat=Wadl&ApiName=Face%20API%20-%20V1.0 .
It will be great if you guys fix this in definitions too.