### PR TITLE
Fix/face api identify response

### DIFF
--- a/Content/en-us/Face/QuickStarts/CSharp.md
+++ b/Content/en-us/Face/QuickStarts/CSharp.md
@@ -87,7 +87,7 @@ namespace CSHttpClientSample
 #### Face - Detect Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
 
-```php
+```json
 [
     {
         "faceId": "c5c24a82-6845-4031-9d5d-978df9175426",

--- a/Content/en-us/Face/QuickStarts/Java.md
+++ b/Content/en-us/Face/QuickStarts/Java.md
@@ -80,7 +80,7 @@ public class Main
 #### Face - Detect Response
 A successful response will be returned in JSON. The following is an example of a successful response: 
 
-```php
+```json
 [
     {
         "faceId": "c5c24a82-6845-4031-9d5d-978df9175426",

--- a/Content/en-us/Face/QuickStarts/JavaScript.md
+++ b/Content/en-us/Face/QuickStarts/JavaScript.md
@@ -65,7 +65,7 @@ to detect faces in an image and return face attributes including:
 #### Face - Detect Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
 
-```php
+```json
 [
     {
         "faceId": "c5c24a82-6845-4031-9d5d-978df9175426",
@@ -249,7 +249,7 @@ identify people based on a detected face and people database (defined as a perso
 ```
 #### Face - Identify Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
-```php
+```json
 [
     {
         "faceId":"c5c24a82-6845-4031-9d5d-978df9175426",

--- a/Content/en-us/Face/QuickStarts/JavaScript.md
+++ b/Content/en-us/Face/QuickStarts/JavaScript.md
@@ -250,26 +250,24 @@ identify people based on a detected face and people database (defined as a perso
 #### Face - Identify Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
 ```php
-{
-    [
-        {
-            "faceId":"c5c24a82-6845-4031-9d5d-978df9175426",
-            "candidates":[
-                {
-                    "personId":"25985303-c537-4467-b41d-bdb45cd95ca1",
-                    "confidence":0.92
-                }
-            ]
-        },
-        {
-            "faceId":"65d083d4-9447-47d1-af30-b626144bf0fb",
-            "candidates":[
-                {
-                    "personId":"2ae4935b-9659-44c3-977f-61fac20d0538",
-                    "confidence":0.89
-                }
-            ]
-        }
-    ]
-}
+[
+    {
+        "faceId":"c5c24a82-6845-4031-9d5d-978df9175426",
+        "candidates":[
+            {
+                "personId":"25985303-c537-4467-b41d-bdb45cd95ca1",
+                "confidence":0.92
+            }
+        ]
+    },
+    {
+        "faceId":"65d083d4-9447-47d1-af30-b626144bf0fb",
+        "candidates":[
+            {
+                "personId":"2ae4935b-9659-44c3-977f-61fac20d0538",
+                "confidence":0.89
+            }
+        ]
+    }
+]
 ```

--- a/Content/en-us/Face/QuickStarts/PHP.md
+++ b/Content/en-us/Face/QuickStarts/PHP.md
@@ -255,27 +255,25 @@ catch (HttpException $ex)
 #### Face - Identify Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
 ```php
-{
-    [
-        {
-            "faceId":"c5c24a82-6845-4031-9d5d-978df9175426",
-            "candidates":[
-                {
-                    "personId":"25985303-c537-4467-b41d-bdb45cd95ca1",
-                    "confidence":0.92
-                }
-            ]
-        },
-        {
-            "faceId":"65d083d4-9447-47d1-af30-b626144bf0fb",
-            "candidates":[
-                {
-                    "personId":"2ae4935b-9659-44c3-977f-61fac20d0538",
-                    "confidence":0.89
-                }
-            ]
-        }
-    ]
-}
+[
+    {
+        "faceId":"c5c24a82-6845-4031-9d5d-978df9175426",
+        "candidates":[
+            {
+                "personId":"25985303-c537-4467-b41d-bdb45cd95ca1",
+                "confidence":0.92
+            }
+        ]
+    },
+    {
+        "faceId":"65d083d4-9447-47d1-af30-b626144bf0fb",
+        "candidates":[
+            {
+                "personId":"2ae4935b-9659-44c3-977f-61fac20d0538",
+                "confidence":0.89
+            }
+        ]
+    }
+]
 ```
 

--- a/Content/en-us/Face/QuickStarts/PHP.md
+++ b/Content/en-us/Face/QuickStarts/PHP.md
@@ -68,7 +68,7 @@ catch (HttpException $ex)
 #### Face - Detect Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
 
-```php
+```json
 [
     {
         "faceId": "c5c24a82-6845-4031-9d5d-978df9175426",
@@ -254,7 +254,7 @@ catch (HttpException $ex)
 ```
 #### Face - Identify Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
-```php
+```json
 [
     {
         "faceId":"c5c24a82-6845-4031-9d5d-978df9175426",

--- a/Content/en-us/Face/QuickStarts/Python.md
+++ b/Content/en-us/Face/QuickStarts/Python.md
@@ -83,7 +83,7 @@ except Exception as e:
 #### Face - Detect Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
 
-```php
+```json
 [
     {
         "faceId": "c5c24a82-6845-4031-9d5d-978df9175426",

--- a/Content/en-us/Face/QuickStarts/Ruby.md
+++ b/Content/en-us/Face/QuickStarts/Ruby.md
@@ -222,26 +222,24 @@ puts response.body
 #### Face - Identify Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
 ```php
-{
-    [
-        {
-            "faceId":"c5c24a82-6845-4031-9d5d-978df9175426",
-            "candidates":[
-                {
-                    "personId":"25985303-c537-4467-b41d-bdb45cd95ca1",
-                    "confidence":0.92
-                }
-            ]
-        },
-        {
-            "faceId":"65d083d4-9447-47d1-af30-b626144bf0fb",
-            "candidates":[
-                {
-                    "personId":"2ae4935b-9659-44c3-977f-61fac20d0538",
-                    "confidence":0.89
-                }
-            ]
-        }
-    ]
-}
+[
+    {
+        "faceId":"c5c24a82-6845-4031-9d5d-978df9175426",
+        "candidates":[
+            {
+                "personId":"25985303-c537-4467-b41d-bdb45cd95ca1",
+                "confidence":0.92
+            }
+        ]
+    },
+    {
+        "faceId":"65d083d4-9447-47d1-af30-b626144bf0fb",
+        "candidates":[
+            {
+                "personId":"2ae4935b-9659-44c3-977f-61fac20d0538",
+                "confidence":0.89
+            }
+        ]
+    }
+]
 ```

--- a/Content/en-us/Face/QuickStarts/Ruby.md
+++ b/Content/en-us/Face/QuickStarts/Ruby.md
@@ -51,7 +51,7 @@ puts response.body
 #### Face - Detect Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
 
-```php
+```json
 [
     {
         "faceId": "c5c24a82-6845-4031-9d5d-978df9175426",
@@ -221,7 +221,7 @@ puts response.body
 
 #### Face - Identify Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
-```php
+```json
 [
     {
         "faceId":"c5c24a82-6845-4031-9d5d-978df9175426",

--- a/Content/en-us/Face/QuickStarts/curl.md
+++ b/Content/en-us/Face/QuickStarts/curl.md
@@ -192,26 +192,24 @@ curl -v -X POST "https://westus.api.cognitive.microsoft.com/face/v1.0/identify"
 #### Face - Identify Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
 ```php
-{
-    [
-        {
-            "faceId":"c5c24a82-6845-4031-9d5d-978df9175426",
-            "candidates":[
-                {
-                    "personId":"25985303-c537-4467-b41d-bdb45cd95ca1",
-                    "confidence":0.92
-                }
-            ]
-        },
-        {
-            "faceId":"65d083d4-9447-47d1-af30-b626144bf0fb",
-            "candidates":[
-                {
-                    "personId":"2ae4935b-9659-44c3-977f-61fac20d0538",
-                    "confidence":0.89
-                }
-            ]
-        }
-    ]
-}
+[
+    {
+        "faceId":"c5c24a82-6845-4031-9d5d-978df9175426",
+        "candidates":[
+            {
+                "personId":"25985303-c537-4467-b41d-bdb45cd95ca1",
+                "confidence":0.92
+            }
+        ]
+    },
+    {
+        "faceId":"65d083d4-9447-47d1-af30-b626144bf0fb",
+        "candidates":[
+            {
+                "personId":"2ae4935b-9659-44c3-977f-61fac20d0538",
+                "confidence":0.89
+            }
+        ]
+    }
+]
 ```

--- a/Content/en-us/Face/QuickStarts/curl.md
+++ b/Content/en-us/Face/QuickStarts/curl.md
@@ -35,7 +35,7 @@ curl -v -X POST "https://westus.api.cognitive.microsoft.com/face/v1.0/detect?ret
 #### Face - Detect Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
 
-```php
+```json
 [
     {
         "faceId": "c5c24a82-6845-4031-9d5d-978df9175426",
@@ -191,7 +191,7 @@ curl -v -X POST "https://westus.api.cognitive.microsoft.com/face/v1.0/identify"
 ```
 #### Face - Identify Response
 A successful response will be returned in JSON. Following is an example of a successful response: 
-```php
+```json
 [
     {
         "faceId":"c5c24a82-6845-4031-9d5d-978df9175426",


### PR DESCRIPTION
Fixed invalid response example for identify response. It should be an array, not an object.
Fixed code type (```php -> ```json).

Note that the same invalid response example is in swagger and wadl api definitions ( same thing as #225 )